### PR TITLE
bug fix: tree does not work if the object contains null

### DIFF
--- a/ion-tree-list.js
+++ b/ion-tree-list.js
@@ -7,7 +7,7 @@ var CONF = {
 
 function addDepthToTree(obj, depth, collapsed) {
     for (var key in obj) {
-        if (typeof(obj[key]) == 'object') {
+        if ( obj[key] && typeof(obj[key]) == 'object') {
             obj[key].depth = depth;
             obj[key].collapsed = collapsed;
             addDepthToTree(obj[key], key === 'tree' ? ++ depth : depth, collapsed)
@@ -18,7 +18,7 @@ function addDepthToTree(obj, depth, collapsed) {
 
 function toggleCollapse(obj) {
     for (var key in obj) {
-        if (typeof(obj[key]) == 'object') {
+        if ( obj[key] && typeof(obj[key]) == 'object') {
             obj[key].collapsed = !obj[key].collapsed;
             toggleCollapse(obj[key])
         }


### PR DESCRIPTION
I found that the tree structure does not work properly when the object contains null. The comparison "typeof(obj) == 'object'" will be true if obj is null, so the following code sometimes fails:

```
    if ( typeof(obj[key]) == 'object' ) {
        obj[key].depth = depth;
        obj[key].collapsed = collapsed;
        addDepthToTree(obj[key], key === 'tree' ? ++ depth : depth, collapsed)
    }
```

My modification is to ensure obj[key] cannot be null.
