### PR TITLE
Add support for 'collapsible' attribute (#26)

### DIFF
--- a/ion-tree-list.js
+++ b/ion-tree-list.js
@@ -36,13 +36,14 @@ angular.module('ion-tree-list', [], function($rootScopeProvider){
         scope: {
             items: '=',
             collapsed: '=',
+            collapsible: '=',
             templateUrl: '@',
             showReorder: '='
         },
         templateUrl: CONF.baseUrl + '/ion-tree-list.tmpl.html',
         controller: function($scope){
             $scope.baseUrl = CONF.baseUrl;
-            $scope.toggleCollapse = toggleCollapse;
+            $scope.toggleCollapse = ($scope.collapsible === false) ? function(){} : toggleCollapse;
             $scope.templateUrl = $scope.templateUrl ? $scope.templateUrl : 'item_default_renderer';
             
             $scope.emitEvent = function(item){


### PR DESCRIPTION
Not much to say about it, my idea was to replace `$scope.toggleCollapse` with a dummy if an attribute `collapsible` is explicitly false. It still works with `collapsed="true"` although it would make little sense to use that combination in practice.

I didn't include a proposed readme change because I'm not sure where this could best be documented in the current readme structure.
