### PR TITLE
Add support for 'collapsible' item property (#26)

### DIFF
--- a/ion-tree-list.js
+++ b/ion-tree-list.js
@@ -42,7 +42,11 @@ angular.module('ion-tree-list', [], function($rootScopeProvider){
         templateUrl: CONF.baseUrl + '/ion-tree-list.tmpl.html',
         controller: function($scope){
             $scope.baseUrl = CONF.baseUrl;
-            $scope.toggleCollapse = toggleCollapse;
+            $scope.toggleCollapse = function(item) {
+                if (item && item.collapsible !== false) {
+                    toggleCollapse(item);
+                }
+            };
             $scope.templateUrl = $scope.templateUrl ? $scope.templateUrl : 'item_default_renderer';
             
             $scope.emitEvent = function(item){


### PR DESCRIPTION
After submitting PR #27 I thought that it may actually be a much nicer solution to implement this as an item property rather than a directive attribute. This way only parts of the tree can be made uncollapsible if desired, and it doesn't clutter the directive with more attributes.
