### PR TITLE
Update package.json to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "gulp-release-tasks": "0.0.3",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.3",
-    "karma-html2js-preprocessor": "^0.1.0",
-    "karma-jasmine": "^0.3.6",
-    "karma-ng-html2js-preprocessor": "^0.2.0",
+    "karma-html2js-preprocessor": "^1.0.0",
+    "karma-jasmine": "^1.0.2",
+    "karma-ng-html2js-preprocessor": "^1.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
-    "phantomjs": "^2.1.3"
+    "phantomjs-prebuilt": "^2.1.7"
   },
   "dependencies": {
     "bower": "^1.7.7"


### PR DESCRIPTION
- **Updated `phantomjs` package references to `phantomjs-prebuilt`.**

> The package `phantomjs` had renamed to `phantomjs-prebuilt`, updated it and got it work, otherwise `gulp test` will throw an error.
> 
> ```
> npm WARN deprecated phantomjs@2.1.3: Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt'
> ```
- **Updated all npm dependencies.** 

> By exected the gulp task:
> 
> ```
> gulp updateNpmDependencies
> ```

NOTE: Ran the unit test script. It works fine.
