### PR TITLE
smoother when load and collapse 

### DIFF
--- a/ion-tree-list.js
+++ b/ion-tree-list.js
@@ -18,10 +18,10 @@ function addDepthToTree(obj, depth, collapsed) {
 }
 
 function toggleCollapse(obj) {
-    for (var key in obj) {
-        if (obj[key] && typeof(obj[key]) == 'object') {
-            obj[key].collapsed = !obj[key].collapsed;
-            toggleCollapse(obj[key])
+    if (obj.tree) {
+        obj.tree.collapsed = !obj.tree.collapsed;
+        for (var i = 0; i < obj.tree.length; i++) {
+            obj.tree[i].collapsed = !obj.tree[i].collapsed;
         }
     }
     return obj

--- a/ion-tree-list.tmpl.html
+++ b/ion-tree-list.tmpl.html
@@ -15,7 +15,7 @@
     </ion-item>
     <ion-list ng-model="item.tree"
               ng-repeat="item in item.tree"
-              ng-hide="item.collapsed"
+              ng-if="!item.collapsed"
               ng-include="'items_renderer'"
               show-reorder="showReorder">
     </ion-list>


### PR DESCRIPTION
Tree list that has hundreds of items act very slow when page enter and collapse. By creating divs by hierarchy only when collapse can improve performance.